### PR TITLE
add IPv6 support (rfc2428)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ _$*
 *.ln
 core
 # CVS default ignores end
+ftp.proxy

--- a/doc/ftp.proxy.1
+++ b/doc/ftp.proxy.1
@@ -322,6 +322,10 @@ The following options can be set:
 \fBacp\fR \fI/path/to/acp\fR
 sets the path to the access control program (\fB-a\fR option).
 .TP
+\fBipv6\fR yes|no
+If enabled the proxy will expect and use IPv6 addresses for all communication.
+Only the extended FTP modes EPSV and EPRT are allowed with IPv6.
+.TP
 \fBallow-anyremote\fR yes|no
 if enabled \fIftp.proxy\fR does not check the remote's end in data
 connection, required for some bad multi-homed servers and FXP (\fB-y\fR

--- a/doc/ftp.proxy.1
+++ b/doc/ftp.proxy.1
@@ -21,7 +21,7 @@ ftp.proxy \- FTP proxy server
 .SH DESCRIPTION
 .I ftp.proxy
 is a proxy server for a subset of the file tranfer protocol described in
-RFC 959.
+RFC 959, it also implements RFC 2428.
 It forwards traffic between a client and a \fIserver\fR without looking too much
 if both hosts do real FTP.
 The FTP server can be either given on the command line or supplied by the
@@ -41,7 +41,7 @@ supports the following FTP commands:
 .RS
 ABOR, ACCT, APPE, CDUP, CWD, DELE, FEAT, LIST,
 .br
-MDTM, MKD, MODE, NLIST, NOOP, PASS, PASV, PORT,
+MDTM, MKD, MODE, NLIST, NOOP, PASS, PASV, PORT, EPSV, EPRT,
 .br
 PWD, QUIT, RETR, REST, RNFR, RNTO, RMD, SITE,
 .br

--- a/doc/ftp.proxy.1
+++ b/doc/ftp.proxy.1
@@ -439,6 +439,10 @@ interface.
 .SH OPTIONS
 The following options are available:
 .TP
+\fB-6\fR
+IPv6 mode. The proxy will expect and use IPv6 addresses for all communication.
+Only the extended FTP modes EPSV and EPRT are allowed with IPv6. The proxy is in IPv4 mode by default.
+.TP
 \fB-a\fR \fIacp\fR
 specify an access control program that grants or denies access via
 \fIftp.proxy\fR.

--- a/samples/forward-ipv6.sh
+++ b/samples/forward-ipv6.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+ftp.proxy -6 -de -D 2001 -r forward

--- a/samples/ftpproxy.conf
+++ b/samples/ftpproxy.conf
@@ -1,4 +1,5 @@
 
+ipv6	no
 
 allow-blanks	yes
 selectserver	yes

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,7 +27,7 @@ TARGETS =	ftp.proxy
 
 
 all:		$(TARGETS)
-	-ctags *.[ch]
+#	-ctags *.[ch]
 
 ftp.proxy:	$(FTPPROXY)
 	$(CC) -o $@ $(FTPPROXY) ${OSLIB}

--- a/src/config.c
+++ b/src/config.c
@@ -172,6 +172,8 @@ int readconfig(config_t *config, char *filename, char *section)
 			config->allow_passwdblanks = get_yesno(&p, word, filename, lineno);
 		else if (strcmp(word, "extra-logging") == 0)
 			extralog = get_yesno(&p, word, filename, lineno);
+		else if (strcmp(word, "ipv6") == 0)
+			use_ipv6 = get_yesno(&p, word, filename, lineno);
 		else if (strcmp(word, "monitormode") == 0)
 			config->monitor = get_yesno(&p, word, filename, lineno);
 		else if (strcmp(word, "proxy-routing") == 0)

--- a/src/ftp.c
+++ b/src/ftp.c
@@ -124,9 +124,12 @@ int get_client_info(ftp_t *x, int pfd)
 {
 	unsigned int size;
 	struct sockaddr_in saddr;
-	struct in_addr *addr;
+#ifdef USE_GETADDRINFO
+	int ret;
+#else
 	struct hostent *hostp = NULL;
-
+	struct in_addr *addr;
+#endif
 	*x->client.name = 0;
 	size = sizeof(saddr);
 	if (getpeername(pfd, (struct sockaddr *) &saddr, &size) < 0 )
@@ -137,11 +140,18 @@ int get_client_info(ftp_t *x, int pfd)
 	if (x->config->numeric_only == 1)
 		copy_string(x->client.name, x->client.ipnum, sizeof(x->client.name));
 	else {
-		addr = &saddr.sin_addr,
+#ifdef USE_GETADDRINFO
+		ret = getnameinfo ((struct sockaddr*) &saddr, sizeof(saddr),
+		                   x->client.name, sizeof(x->client.name), NULL, 0, 0);
+		if (ret != 0) {
+			*(x->client.name) = 0; // error, make sure string is empty
+		}
+#else
+		addr = &saddr.sin_addr;
 		hostp = gethostbyaddr((char *) addr,
 				sizeof (saddr.sin_addr.s_addr), AF_INET);
-
 		copy_string(x->client.name, hostp == NULL? x->client.ipnum: hostp->h_name, sizeof(x->client.name));
+#endif
 		}
 
 	strlwr(x->client.name);
@@ -1354,7 +1364,11 @@ int dologin(ftp_t *x)
 {
 	int	c, i, rc, isredirected;
 	char	*p, word[80], line[300];
+#ifdef USE_GETADDRINFO
+	struct addrinfo *hostp;
+#else
 	struct hostent *hostp;
+#endif
 	struct sockaddr_in saddr;
 			
 	while (1) {
@@ -1527,18 +1541,24 @@ int dologin(ftp_t *x)
 	/*
 	 * Get port and IP number of server.
 	 */
-
 	x->server.port = get_port(x->server.name, 21);
-	if ((hostp = gethostbyname(x->server.name)) == NULL) {
+#ifdef USE_GETADDRINFO
+	hostp = lookup_host (x->server.name, NULL, x->server.port);
+#else
+	hostp = gethostbyname(x->server.name);
+#endif
+	if (hostp == NULL) {
 		cfputs(x, "500 service unavailable");
 		printerror(1 | ERR_PROXY, "-ERR", "can't resolve hostname: %s", x->server.name);
 		exit (1);
 		}
-
+#ifdef USE_GETADDRINFO
+	memcpy (&saddr, hostp->ai_addr, hostp->ai_addrlen);
+	freeaddrinfo (hostp);
+#else
 	memcpy(&saddr.sin_addr, hostp->h_addr, hostp->h_length);
+#endif
 	copy_string(x->server.ipnum, inet_ntoa(saddr.sin_addr), sizeof(x->server.ipnum));
-
-
 
 	/*
 	 * Call the access control program to check if the proxy

--- a/src/ip-lib.c
+++ b/src/ip-lib.c
@@ -44,6 +44,31 @@
 #include "lib.h"
 #include "ip-lib.h"
 
+#ifdef USE_GETADDRINFO
+struct addrinfo * lookup_host (char * host, char * service, unsigned int port)
+{
+	struct addrinfo hints;
+	struct addrinfo *hostp;
+	char port_s[10];
+
+	memset (&hints, 0, sizeof(hints));
+	hints.ai_flags    = AI_CANONNAME;
+	hints.ai_family   = AF_INET;
+	hints.ai_socktype = SOCK_STREAM;
+
+    if (port || (!service || !*service))
+		snprintf (port_s, sizeof(port_s), "%u", port);
+	else
+		snprintf (port_s, sizeof(port_s), "%s", service);
+
+	if (getaddrinfo (host, port_s, &hints, &hostp) != 0) {
+		return NULL;
+	}
+
+	return hostp;
+}
+#endif
+
 
 unsigned int get_interface_info(int pfd, peer_t *sock)
 {
@@ -71,8 +96,13 @@ static void alarm_handler()
 int openip(char *host, unsigned int port, char *srcip, unsigned int srcport)
 {
 	int	socketd;
+#ifdef USE_GETADDRINFO
+	struct addrinfo *hostp;
+#else
 	struct sockaddr_in server;
+	struct sockaddr_in laddr;
 	struct hostent *hostp;
+#endif
 
 	socketd = socket(AF_INET, SOCK_STREAM, 0);
 	if (socketd < 0)
@@ -84,8 +114,6 @@ int openip(char *host, unsigned int port, char *srcip, unsigned int srcport)
 	 */
 	if (srcip != NULL  &&  *srcip != 0)
 	{
-		struct sockaddr_in laddr;
-
 		if (srcport != 0) {
 			int	one;
 			one = 1;
@@ -93,38 +121,63 @@ int openip(char *host, unsigned int port, char *srcip, unsigned int srcport)
 		}
  
  		/* Bind local socket to srcport and srcip */
-
- 		memset(&laddr, 0, sizeof(laddr));
+#ifdef USE_GETADDRINFO
+		hostp = lookup_host (srcip, NULL, srcport);
+		if (!hostp) {
+#else
+		memset(&laddr, 0, sizeof(laddr));
  		laddr.sin_family = AF_INET;
  		laddr.sin_port   = htons(srcport);
-
 		struct hostent *ifp;
- 
 		ifp = gethostbyname(srcip);
 		if (ifp == NULL) {
+#endif
 			printerror(1 | ERR_SYSTEM, "-ERR", "can't lookup %s", srcip);
 			exit (1);
 		}
+
+#ifdef USE_GETADDRINFO
+		if (bind(socketd, hostp->ai_addr, hostp->ai_addrlen)) {
+			printerror(1 | ERR_SYSTEM, "-ERR", "can't bind to %s:%u", srcip, srcport);
+			freeaddrinfo (hostp);
+			exit (1);
+		}
+		freeaddrinfo (hostp);
+#else
 		memcpy(&laddr.sin_addr, ifp->h_addr, ifp->h_length);
- 
 		if (bind(socketd, (struct sockaddr *) &laddr, sizeof(laddr))) {
 			printerror(1 | ERR_SYSTEM, "-ERR", "can't bind to %s:%u", srcip, ntohs(laddr.sin_port));
 			exit (1);
 		}
+#endif
 	}
 
+#ifdef USE_GETADDRINFO
+	hostp = lookup_host (host, NULL, port);
+	if (!hostp)
+		return -1;
+#else
 	server.sin_family = AF_INET;
 	hostp = gethostbyname(host);
 	if (hostp == NULL)
 		return (-1);
-  
 	memcpy(&server.sin_addr, hostp->h_addr, hostp->h_length);
 	server.sin_port = htons(port);
+#endif
 
 	signal(SIGALRM, alarm_handler);
 	alarm(10);
+
+#ifdef USE_GETADDRINFO
+	if (connect(socketd, hostp->ai_addr, hostp->ai_addrlen) < 0) {
+		freeaddrinfo (hostp);
+		return -1;
+	}
+	freeaddrinfo (hostp);
+#else
 	if (connect(socketd, (struct sockaddr *) &server, sizeof(server)) < 0)
 		return (-1);
+#endif
 
 	alarm(0);
 	signal(SIGALRM, SIG_DFL);
@@ -174,6 +227,11 @@ int bind_to_port(char *interface, unsigned int port)
 {
 	struct sockaddr_in saddr;
 	int	sock;
+#ifdef USE_GETADDRINFO
+	struct addrinfo * ifp;
+#else
+	struct hostent *ifp;
+#endif
 
 	if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
 		printerror(1 | ERR_SYSTEM, "-ERR", "can't create socket: %s", strerror(errno));
@@ -191,14 +249,21 @@ int bind_to_port(char *interface, unsigned int port)
 	if (interface == NULL  ||  *interface == 0)
 		interface = "0.0.0.0";
 	else {
-		struct hostent *ifp;
-
+#ifdef USE_GETADDRINFO
+		ifp = lookup_host (interface, NULL, port);
+#else
 		ifp = gethostbyname(interface);
+#endif
 		if (ifp == NULL) {
 			printerror(1 | ERR_SYSTEM, "-ERR", "can't lookup %s", interface);
 			exit (1);
 		}
-		memcpy(&saddr.sin_addr, ifp->h_addr, ifp->h_length);
+#ifdef USE_GETADDRINFO
+		memcpy (&saddr, ifp->ai_addr, ifp->ai_addrlen);
+		freeaddrinfo (ifp);
+#else
+		memcpy (&saddr.sin_addr, ifp->h_addr, ifp->h_length);
+#endif
 	}
 
 	if (bind(sock, (struct sockaddr *) &saddr, sizeof(saddr))) {

--- a/src/ip-lib.c
+++ b/src/ip-lib.c
@@ -284,6 +284,9 @@ unsigned int get_port(char *server, unsigned int def_port)
 	unsigned int port;
 	char	*p;
 
+	if (use_ipv6)
+		return def_port;
+
 	if ((p = strchr(server, ':')) == NULL)
 		return (def_port);
 

--- a/src/ip-lib.h
+++ b/src/ip-lib.h
@@ -26,12 +26,22 @@
 #define	_IP_LIB_INCLUDED
 
 extern char *program;
+extern int use_ipv6;
 
 typedef struct _peer {
-	char        name[80];
-	char        ipnum[40];
+	char        name[100];
+	char        ipnum[64];
 	unsigned int port;
 	} peer_t;
+
+struct sockaddr * w_sockaddr_new (int ipv6); // must be freed with free()
+int  w_sockaddr_get_port   (struct sockaddr * saddr);
+void w_sockaddr_get_ip_str (struct sockaddr * saddr, char * outbuf, int size);
+void * w_sockaddr_get_addr (struct sockaddr * saddr);
+socklen_t w_sockaddr_get_size (struct sockaddr * saddr);
+void w_sockaddr_reset (struct sockaddr * saddr);
+void w_sockaddr_set_port (struct sockaddr * saddr, int port);
+int w_sockaddr_set_ip_from_str (struct sockaddr * saddr, const char * ipstr);
 
 unsigned int get_interface_info(int pfd, peer_t *sock);
 

--- a/src/ip-lib.h
+++ b/src/ip-lib.h
@@ -25,6 +25,8 @@
 #ifndef _IP_LIB_INCLUDED
 #define	_IP_LIB_INCLUDED
 
+#define USE_GETADDRINFO 1
+
 extern char *program;
 
 typedef struct _peer {
@@ -42,5 +44,8 @@ unsigned int get_port(char *server, unsigned int def_port);
 
 int bind_to_port(char *interface, unsigned int port);
 int accept_loop(int sock);
+#ifdef USE_GETADDRINFO
+struct addrinfo * lookup_host (char * host, char * service, unsigned int port);
+#endif
 
 #endif

--- a/src/ip-lib.h
+++ b/src/ip-lib.h
@@ -25,8 +25,6 @@
 #ifndef _IP_LIB_INCLUDED
 #define	_IP_LIB_INCLUDED
 
-#define USE_GETADDRINFO 1
-
 extern char *program;
 
 typedef struct _peer {
@@ -44,8 +42,6 @@ unsigned int get_port(char *server, unsigned int def_port);
 
 int bind_to_port(char *interface, unsigned int port);
 int accept_loop(int sock);
-#ifdef USE_GETADDRINFO
 struct addrinfo * lookup_host (char * host, char * service, unsigned int port);
-#endif
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -278,8 +278,11 @@ int main(int argc, char *argv[], char *envp[])
 	k = 1;
 	while (k < argc  &&  argv[k][0] == '-'  &&  argv[k][1] != 0) {
 		copy_string(option, argv[k++], sizeof(option));
-		for (i=1; (c = option[i]) != 0; i++) {
-			if (c == 'd') {
+		for (i=1; (c = option[i]) != 0; i++)
+		{
+			if (c == '6')
+				use_ipv6 = 1; /* ip-lib.c */
+			else if (c == 'd') {
 				if (debug == 1)
 					debug = 2;
 				else
@@ -417,6 +420,8 @@ int main(int argc, char *argv[], char *envp[])
 				 * to allow server-server transfers through the
 				 * proxy -- 31JAN02asg
 				 */
+
+
 
 				config->allow_anyremote = 1;
 				}


### PR DESCRIPTION
- support getaddrinfo() / getnameinfo()

- remove calls to gethostbyname() / getaddrbyname()

- iplib: support IPv6

- ftp.c: support EPSV/EPRT (implement rfc2428)
    
    FTP Extensions for IPv6 and NATs
    https://datatracker.ietf.org/doc/html/rfc2428

- new cli param: -6 (use ipv6 for connections)
    
    IPv6 mode. The proxy will expect and use IPv6 addresses for all communication.
    Only the extended FTP modes EPSV and EPRT are allowed with IPv6. The proxy is in IPv4 mode by default

- ftpproxy.conf: ipv6 yes|no

- ip-lib.c: get_port(): use default_port for ipv6 (hack)
    
    this is a temporary hack until a proper fix is devised
    
    host:port makes sense only for ipv4
    
    ipv6 addresses contain ':', so that invalidates get_port()
    
    for ipv6 clients should send something like this (using `-r forward`)
    
    USER user@host port (i.e: USER anonymous@::1 21)
    
    (of course the port is ignored?)
